### PR TITLE
Fix DeprecationWarning in regex match

### DIFF
--- a/pdns_api_client/api_client.py
+++ b/pdns_api_client/api_client.py
@@ -252,12 +252,12 @@ class ApiClient(object):
 
         if type(klass) == str:
             if klass.startswith('list['):
-                sub_kls = re.match('list\[(.*)\]', klass).group(1)
+                sub_kls = re.match(r'list\[(.*)\]', klass).group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('dict('):
-                sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+                sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in iteritems(data)}
 


### PR DESCRIPTION
Without the `r` leads to `DeprecationWarning: invalid escape sequence \[` in Python 3.6+: https://docs.python.org/3/whatsnew/3.6.html#api-and-feature-removals